### PR TITLE
Fixes bin/kyuri failing to exit when testing something with a keep-alive loop. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+
+
+test: vows kyuri
+
+vows:
+	vows --spec
+
+kyuri:
+	./bin/kyuri examples
+
+.PHONY: test vows kyuri
+

--- a/bin/kyuri
+++ b/bin/kyuri
@@ -127,6 +127,10 @@ catch (err) {
 var _waitComplete = function () {
   if (!complete) {
     process.nextTick(_waitComplete);
+  } else { 
+    // make sure the script exits even if something we are testing has anohter
+    // wait for next tick loop going. 
+    process.exit();
   }
 };
 

--- a/examples/complex_space.feature
+++ b/examples/complex_space.feature
@@ -1,0 +1,31 @@
+Feature: Complex Addition
+  In order to avoid silly mistakes
+  As a math idiot
+  I want to be told the sum of two numbers
+
+  Background:
+    Given I have a calculator
+
+  Scenario: Add two numbers
+    Given I have entered "50" and "75" into the calculator
+    And I have entered 70 into the calculator
+    When I press add
+    Then the result should be 120 on the screen
+
+  Scenario Outline: Add three numbers
+    Given I have entered <number1> into the calculator
+    And I have entered <number2> into the calculator
+    And I have entered 120 into the calculator
+    When I press add
+    Then the result should be <number3> on the screen
+    
+    Examples:
+      | number1 | number2 | number3 |
+      | 10      | 20      | 150     |
+      | 20      | 40      | 180     |
+      
+  Scenario: Add two numbers
+    Given I have entered 50 into the calculator
+    And I have entered 70 into the calculator
+    When I press add
+    Then the result should be 120 on the screen

--- a/lib/kyuri/lexer.js
+++ b/lib/kyuri/lexer.js
@@ -9,7 +9,7 @@
 var helpers = require('./helpers'),
     eyes = require('eyes');
 
-var MULTI_DENT        = /^(\t+)(\.)?/,
+var MULTI_DENT          = /^([\t ]+)(\.)?/,
     IS_EXAMPLE_ROW    = /^([\|\s+\S+]+\s+\|\s*)$/,
     PARSE_EXAMPLE_ROW = /\|[^|]+/gi,
     PYSTRING          = /"""/,
@@ -72,6 +72,7 @@ Lexer.prototype = {
     this.source = source;                  // Source code we are attempting to lex
     this.lineNum = 0;                      // Line number of the lexing operation
     this.indents = 0;                      // Number of indents
+    this.indent_size = null;               // tabstop
     this.tokens = [];                      // Stream of parsed tokens in the form ['TYPE', value, line]
     this.lines = this.source.split('\n');  // Split the source code by \n since we have no multi-line statements
     
@@ -232,20 +233,31 @@ Lexer.prototype = {
   },
   
   lineToken: function () {
-    var diff, indent, size;
-    if (!(indent = this.match(MULTI_DENT, 1))) {
+    var diff, size, indent;
+    if (this.i > 0) { // only check line token at the first of the line.
+      return false;
+    }
+    indent = this.match(MULTI_DENT, 1);
+    if (!indent) {
       return false;
     }
     
     size = indent.length;
     this.i += size;
+
+    if (!this.indent_size)  { // assume that first indent is one tabstop
+      this.indent_size = size;
+    }
     
     if (size > this.indents) {
       diff = size - this.indents;
+      diff = Math.round(diff / this.indent_size);
       this.token('INDENT', diff);
     } 
     else if (size < this.indents) {
-      this.token('OUTDENT', this.indents - size);
+      diff = this.indents - size;
+      diff = Math.round(diff / this.indent_size);
+      this.token('OUTDENT', diff);
     }
     
     this.indents = size;

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -54,6 +54,14 @@ vows.describe('kyuri/parser').addBatch({
         assert.isObject(ast);  
         assert.include(ast, 1);
       }
+    },
+    "parsing complex_space.feature": {
+      topic: parseAllLines(path.join(__dirname, '..', 'examples', 'complex_space.feature')),
+      "should parse correctly": function (err, ast) {
+        assert.isNull(err);
+        assert.isObject(ast);  
+        assert.include(ast, 1);
+      }
     }
   }
 }).export(module);


### PR DESCRIPTION
If there is another nextTick loop in what you are testing, kyuri fails to exit.

adding an else process.exit fixes the problem. 
